### PR TITLE
Multiqc for bp project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ for samples present in a supplied vcf file
 as json
 * __run_FastQC_and_MultiQC.sh__ - bash script to run FastQC on a specified project in a runfolder. 
 The script will summarize the output in one or several MultiQC-reports.
+* __run_multiqc_bp_qc.sh__ - A simple wrapper for the MultiQC command used when performing QC of best-practice WGS projects.

--- a/run_multiqc_bp_qc.sh
+++ b/run_multiqc_bp_qc.sh
@@ -4,8 +4,12 @@
 # A simple wrapper for the multiqc command in INS-22349
 # Usage: bash /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
 #
-
+#SBATCH -A ngi2016001
+#SBATCH -n 8
+#SBATCH -t 05:00:00
+#SBATCH -J run_multiqc_bp_qc
+#SBATCH -o run_multiqc_bp_qc.%j.out
 PROJECT_PATH=$1
 
-sbatch -A ngi2016001 -n 8 -t 05:00:00 --wrap "multiqc --template default --config /proj/ngi2016001/private/conf/multiqc_config.yaml --title $(basename $PROJECT_PATH) --filename $(basename $PROJECT_PATH)_$(date +%y%m%d) --outdir multiqc_ngi --data-format json --zip-data-dir --no-push $PROJECT_PATH"
+multiqc --template default --config /proj/ngi2016001/private/conf/multiqc_config.yaml --title "$(basename $PROJECT_PATH)" --filename "$(basename $PROJECT_PATH)_$(date +%y%m%d)" --outdir multiqc_ngi --data-format json --zip-data-dir --no-push "$PROJECT_PATH"
 

--- a/run_multiqc_bp_qc.sh
+++ b/run_multiqc_bp_qc.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -l
+
+#
+# A simple wrapper for the multiqc command in INS-22349
+# Usage: bash /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
+#
+
+PROJECT_PATH=$1
+
+sbatch -A ngi2016001 -n 8 -t 05:00:00 --wrap "multiqc --template default --config /proj/ngi2016001/private/conf/multiqc_config.yaml --title $(basename $PROJECT_PATH) --filename $(basename $PROJECT_PATH)_$(date +%y%m%d) --outdir multiqc_ngi --data-format json --zip-data-dir --no-push $PROJECT_PATH"
+

--- a/run_multiqc_bp_qc.sh
+++ b/run_multiqc_bp_qc.sh
@@ -2,7 +2,9 @@
 
 #
 # A simple wrapper for the multiqc command in INS-22349
-# Usage: bash /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
+# Usage:
+#  - Locally: bash /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
+#  - Submitted to compute node (RECOMMENDED): sbatch /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
 #
 #SBATCH -A ngi2016001
 #SBATCH -n 8


### PR DESCRIPTION
A simple wrapper for the multiqc command in INS-22349.
Usage: `bash /proj/ngi2016001/private/scripts/run_multiqc_bp_qc.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>`

The command is run on a compute node. 
