### PR TITLE
Sample list section in sarek multiqc reports

### DIFF
--- a/run_multiqc_bp_qc.sh
+++ b/run_multiqc_bp_qc.sh
@@ -13,5 +13,10 @@
 #SBATCH -o run_multiqc_bp_qc.%j.out
 PROJECT_PATH=$1
 
-multiqc --template default --config /proj/ngi2016001/private/conf/multiqc_config.yaml --title "$(basename $PROJECT_PATH)" --filename "$(basename $PROJECT_PATH)_$(date +%y%m%d)" --outdir multiqc_ngi --data-format json --zip-data-dir --no-push "$PROJECT_PATH"
+python /proj/ngi2016001/private/scripts/sample_list_for_multiqc.py --path $PROJECT_PATH
 
+if [[ $? == "0" ]]; then
+    multiqc --template default --config /proj/ngi2016001/private/conf/multiqc_config.yaml --title "$(basename $PROJECT_PATH)" --filename "$(basename $PROJECT_PATH)_$(date +%y%m%d)" --outdir multiqc_ngi --data-format json --zip-data-dir --no-push "$PROJECT_PATH"
+else
+    echo "Something went wrong when making the sample list"
+fi

--- a/sample_list_for_multiqc.py
+++ b/sample_list_for_multiqc.py
@@ -1,0 +1,31 @@
+import argparse
+import os
+import csv
+from jinja2 import Environment, FileSystemLoader
+
+parser = argparse.ArgumentParser(description='Make sample list for sarek multiqc report')
+parser.add_argument('-p', '--path', type=str, required=True, help='Path to analysis folder')
+
+args = parser.parse_args()
+analysis_path = args.path
+
+def get_sample_names(analysis_path):
+    samples = []
+    for root, dirs, files in os.walk(analysis_path, followlinks=True):
+        for name in files:
+            if name.endswith("SarekGermlineAnalysis.tsv"):
+                file_path = os.path.join(root, name)
+                with open(file_path) as f:
+                    reader = csv.reader(f, delimiter = "\t")
+                    for row in reader:
+                        samples.append(row[0])
+    # yield unique sample names
+    for sample in sorted(set(samples)):
+        yield sample
+
+env = Environment(loader=FileSystemLoader(searchpath=os.path.dirname(os.path.realpath(__file__))))
+
+template = env.get_template('sample_list_template.yaml.j2')
+out_file = os.path.join(analysis_path, "sample_list_mqc.yaml")
+template.stream(sample_names=get_sample_names(analysis_path)).dump(out_file)
+

--- a/sample_list_template.yaml.j2
+++ b/sample_list_template.yaml.j2
@@ -1,0 +1,12 @@
+
+id: 'sample_list'
+section_name: 'List of samples'
+plot_type: 'html'
+description: 'included in the analysis'
+data: |
+    <ul>
+    {% for sample_name in sample_names %}
+        <li>{{sample_name}}</li>
+    {% endfor %}
+    </ul>
+


### PR DESCRIPTION
This PR includes a new script that will generate a yaml file (MultiQC custom content) that will add a sample list section to the MultiQC report. 

I also updated the `run_multiqc_bp_qc.sh` to run the script before making the MultiQC report. I have assumed that this script only is used for making reports for sarek analysis results, this might not be true.  In that case I can remove my changes from that script. 