### PR TITLE
include custom multiqc content, submit independent multiqc jobs

### DIFF
--- a/multiqc_pipeline_info.py
+++ b/multiqc_pipeline_info.py
@@ -1,0 +1,96 @@
+import os
+import re
+import sys
+
+"""
+Simple script to recreate the custom MultiQC content that the Sarek pipeline generates for the
+pipeline_info output
+"""
+
+
+def pipeline_report_header():
+    return """
+id: 'sarek-summary'
+description: " - this information is collected when the pipeline is started."
+section_name: 'nf-core/sarek Workflow Summary'
+section_href: 'https://github.com/nf-core/sarek'
+plot_type: 'html'
+data: |
+    <dl class=\"dl-horizontal\">
+"""
+
+
+def software_version_header():
+    return """
+id: 'software_versions'
+section_name: 'nf-core/sarek software versions'
+section_href: 'https://github.com/nf-core/sarek'
+plot_type: 'html'
+description: 'are collected at run time from the software output.'
+data: |
+    <dl class="dl-horizontal">
+"""
+
+
+def pipeline_report_file(d="."):
+    return os.path.join(d, "pipeline_report.txt")
+
+
+def software_version_file(d="."):
+    return os.path.join(d, "software_versions.csv")
+
+
+def pipeline_report_mqc(d="."):
+    return os.path.join(d, "workflow_summary_mqc.yaml")
+
+
+def software_version_mqc(d="."):
+    return os.path.join(d, "software_versions_mqc.yaml")
+
+
+def pipeline_report_pattern():
+    return r'^\s+-\s+([^:]+):\s(.+)$'
+
+
+def software_version_pattern():
+    return r'^\s*(\S+)\t+(.*\S)\s*$'
+
+
+def parse_report_with_pattern(report_file, pattern):
+    data = {}
+    with open(report_file, "r") as f:
+        for g in filter(
+                lambda x: x is not None,
+                map(
+                    lambda x: re.match(pattern, x),
+                    f)):
+            data[g.group(1)] = g.group(2)
+    return data
+
+
+def write_mqc(mqc_file, header, data):
+    with open(mqc_file, "w") as f:
+        f.write(header)
+        for k, v in data.items():
+            f.write(f"        <dt>{k}</dt><dd><samp>{v}</samp></dd>\n")
+        f.write("    </dl>\n")
+
+
+indir = sys.argv[1]
+outdir = sys.argv[2]
+
+for header_f, pattern_f, file_f, mqc_f in (
+        (pipeline_report_header,
+         pipeline_report_pattern,
+         pipeline_report_file,
+         pipeline_report_mqc),
+        (software_version_header,
+         software_version_pattern,
+         software_version_file,
+         software_version_mqc)):
+    write_mqc(
+        mqc_f(d=outdir),
+        header_f(),
+        parse_report_with_pattern(
+            file_f(d=indir),
+            pattern_f()))

--- a/multiqc_sarek_project.sh
+++ b/multiqc_sarek_project.sh
@@ -2,24 +2,23 @@
 
 # Script for making project level MultiQC reports for sarek
 # Two reports are made: One for a bioinformatician to inspect QC and one to send to the user.
-# Before the reports are generated, a MultiQC custom content config is generated to add a sample list section to the reports.
+# Before the reports are generated, a MultiQC custom content config is generated to add a sample list section and
+# pipeline info to the reports.
+#
+# This script will in turn submit two separate slurm jobs for generating the reports and then exit
 #
 # Usage:
-#  - Locally: bash multiqc_sarek_project.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
-#  - Submitted to compute node (RECOMMENDED): sbatch multiqc_sarek_project.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
+#  - bash multiqc_sarek_project.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project>
 #
 # A custom script location can be supplied as a second argument (useful during testing):
 #   - bash multiqc_sarek_project.sh /proj/ngi2016001/nobackup/NGI/ANALYSIS/<project> /path/to/scripts_dir
 #
-#SBATCH -A ngi2016001
-#SBATCH -n 8
-#SBATCH -t 05:00:00
-#SBATCH -J sarek_multiQC
-#SBATCH -o multiqc_sarek_project.%j.out
+
 PROJECT_PATH=$1
 PROJECT_ID=$(basename $PROJECT_PATH)
 REPORT_FILENAME=$PROJECT_ID"_multiqc_report"
 REPORT_FILENAME_QC=$PROJECT_ID"_multiqc_report_qc"
+REPORT_OUTDIR="${PROJECT_PATH}/multiqc_ngi"
 
 if [ -z "$2" ]
   then
@@ -41,12 +40,58 @@ check_errors()
 
 source activate NGI
 
-python $SCRIPTS_DIR"/sample_list_for_multiqc.py" --path $PROJECT_PATH
+# Generate custom content listing the samples in the project
+python "$SCRIPTS_DIR/sample_list_for_multiqc.py" --path "${PROJECT_PATH}"
 check_errors $? "Something went wrong when making the sample list"
 
-multiqc -f --template default --config $CONFIG_DIR"/multiqc_config_wgs.yaml" --config $CONFIG_DIR"/multiqc_config_wgs_qc.yaml" --title $PROJECT_ID --filename $REPORT_FILENAME_QC --outdir $PROJECT_PATH"/multiqc_ngi" --data-format json --zip-data-dir --no-push $PROJECT_PATH
-check_errors $? "Something went wrong when making the report for QC"
+mqc_content="$PROJECT_PATH/multiqc_custom_content"
+mkdir -p "$mqc_content"
+mv "$PROJECT_PATH/sample_list_mqc.yaml" "$mqc_content/"
 
-multiqc -f --template default --config $CONFIG_DIR"/multiqc_config_wgs.yaml" --title $PROJECT_ID --filename $REPORT_FILENAME --outdir $PROJECT_PATH"/multiqc_ngi" --data-format json --zip-data-dir --no-push $PROJECT_PATH
-check_errors $? "Something went wrong when making the user report"
+# Generate custom content based on the pipeline_info output
+infodir="$(find "$PROJECT_PATH" -mindepth 3 -maxdepth 4 -type d -name "pipeline_info" -a -path "*/results/*" -print -quit)"
+if [ -e "${infodir}" ]
+then
+  python "$SCRIPTS_DIR/multiqc_pipeline_info.py" "$infodir" "$mqc_content"
+fi
 
+# Gather a list of input dirs to give to MultiQC, exclude report directories not placed directly under the main sample
+# (i.e. reports for individual lanes etc. will be excluded)
+sed -nre 's/^.*<li>([^<]+)<\/li>.*$/\1/p' "$mqc_content/sample_list_mqc.yaml" > "$mqc_content/sample_names.txt"
+INPUT_DIRS="$mqc_content $(find "$PROJECT_PATH" -mindepth 4 -maxdepth 5 -type d -name "${PROJECT_ID}*" -a -path "*/Reports/*" |grep -f <(while read s; do echo "$s\$"; done < "$mqc_content/sample_names.txt") | paste -s -d' ')"
+
+# submit MultiQC jobs to SLURM
+SBATCH_A=ngi2016001
+SBATCH_n=2
+SBATCH_t=12:00:00
+SBATCH_D="${REPORT_OUTDIR}"
+
+mkdir -p "${REPORT_OUTDIR}"
+
+SBATCH_J="${PROJECT_ID}_multiqc_qc"
+sbatch -A ${SBATCH_A} -D "${SBATCH_D}" -n ${SBATCH_n} -t ${SBATCH_t} -J "${SBATCH_J}" -o "${SBATCH_J}.%j.out" --wrap "multiqc \
+  -f \
+  --template default \
+  --config '$CONFIG_DIR/multiqc_config_wgs.yaml' \
+  --config '$CONFIG_DIR/multiqc_config_wgs_qc.yaml' \
+  --title '$PROJECT_ID' \
+  --filename '$REPORT_FILENAME_QC' \
+  --outdir '$REPORT_OUTDIR' \
+  --data-format json \
+  --zip-data-dir \
+  --no-push \
+  --interactive \
+  $INPUT_DIRS"
+
+SBATCH_J="${PROJECT_ID}_multiqc"
+sbatch -A ${SBATCH_A} -D "${SBATCH_D}" -n ${SBATCH_n} -t ${SBATCH_t} -J "${SBATCH_J}" -o "${SBATCH_J}.%j.out" --wrap "multiqc \
+  -f \
+  --template default \
+  --config '$CONFIG_DIR/multiqc_config_wgs.yaml' \
+  --title '$PROJECT_ID' \
+  --filename '$REPORT_FILENAME' \
+  --outdir '$REPORT_OUTDIR' \
+  --data-format json \
+  --zip-data-dir \
+  --no-push \
+  $INPUT_DIRS"


### PR DESCRIPTION
This PR brings a few changes to the MultiQC reports that are manually created after Sarek has been run for a project.

- The information in `pipeline_info/software_versions.csv` and `pipeline_info/pipeline_report.txt` is parsed and exported as custom content (`_mqc.yaml`) so that MultiQC will recognize it and include in the report
- The custom content is collected into a single directory that is listed as input to MultiQC
- The input paths to MultiQC is more specific and only includes the main sample dirs from `results/Reports` (i.e. the data for individual lanes/preps are omitted)
- The QC report will be forced to be interactive by default
- The script submits two independent slurm jobs for generating the reports, rather then generating the reports directly. Thus, the `multiqc_sarek_project.sh` script itself should just be run as a bash script

Opinions and objections welcome!
  