### PR TITLE
use find to find correct path

### DIFF
--- a/create_nf_samplesheet.sh
+++ b/create_nf_samplesheet.sh
@@ -28,7 +28,7 @@ mkdir -p ${FQDIR}
 
 find "${DATADIR}" -name "*.fastq.gz" -exec ln -s {} "${FQDIR}/" \;
 
-python "$ENVPATH/sw/rnaseq/workflow/bin/fastq_dir_to_samplesheet.py" \
+python "$(find "$ENVPATH/sw/rnaseq" -name "fastq_dir_to_samplesheet.py" -print -quit)" \
   --sanitise_name \
   --sanitise_name_index=1 \
   --strandedness=reverse \

--- a/twist_exome_38_template.sbatch
+++ b/twist_exome_38_template.sbatch
@@ -26,6 +26,8 @@ GENOMESPARAM="--genome GRCh38"
 PROFILE="-profile uppmax"
 SAREKTAG="=SAREKTAG="
 
+SAREKPATH="$(dirname "$(find "${VERSIONPATH}/sw/sarek" -name "main.nf" -print -quit)")"
+
 date '+%Y-%m-%d %R:%S' |tee "${RUNDEBUG}"
 cat "${0}" >> "${RUNDEBUG}"
 echo "" > "${EXITCODE}"
@@ -34,7 +36,7 @@ source "${VERSIONPATH}/conf/sourceme_upps.sh"
 source activate NGI
 
 nextflow run \
-  "${VERSIONPATH}/sw/sarek/workflow/" \
+  "${SAREKPATH}" \
     ${PROFILE} \
     --project ngi2016001 \
     -c "${VERSIONPATH}/conf/nextflow_miarka_upps.config" \


### PR DESCRIPTION
With the updated version of `nf-core` on miarka, the path to the nextflow pipeline scripts changes. This fixes that for the `create_nf_samplesheet.sh` script.
