### PR TITLE
Fix printing of 30x coverage threshold

### DIFF
--- a/multiqc_extra_stats_qc.py
+++ b/multiqc_extra_stats_qc.py
@@ -38,7 +38,7 @@ class QC:
     def pretty_limits(self, metric):
         lt, ut = self.limits(metric)
         match metric:
-            case "Coverage ≥10 X" | "Coverage ≥10 X":
+            case "Coverage ≥10 X" | "Coverage ≥30 X":
                 return f"≥ {lt} X"
             case "Unfiltered variants":
                 return f"{lt / 1000000:.1f}-{ut / 1000000:.1f} M"


### PR DESCRIPTION
Fixed bug so that threshold value for Coverage >= 30X now is displayed correctly in the report