### PR TITLE
update trim params flag according to rnaseq 3.12

### DIFF
--- a/run_script_templates/rnaseq_template
+++ b/run_script_templates/rnaseq_template
@@ -16,7 +16,7 @@ export NXF_WORK=_ANALYSISDIR_/_PROJECT_/work
 rnaseq -resume _CONFIG_ --genome _GENOME_ \
     --input _ANALYSISDIR_/_PROJECT_/_PROJECT_.SampleSheet.csv \
     --outdir _ANALYSISDIR_/_PROJECT_/results \
-    --clip_r1 1 --clip_r2 1 --three_prime_clip_r1 1 --three_prime_clip_r2 1 _EXTRAARGS_
+    --extra_trimgalore_args "--clip_r1 1 --clip_r2 1 --three_prime_clip_r1 1 --three_prime_clip_r2 1" _EXTRAARGS_
 
 # some files get very restrictive permissions, so change them
 chmod 660 _ANALYSISDIR_/_PROJECT_/results/pipeline_info/*


### PR DESCRIPTION
Update of rnaseq run script template to fix hoqtrimming parameters are called so that the syntax adhere to the current pipeline version in production (3.12)

https://snpseq.atlassian.net/browse/DATAOPS-1157?atlOrigin=eyJpIjoiZjlmMjcwYTgwNjA0NGI2ZGFjMDAxY2I5ZWIxMGNmNDciLCJwIjoiaiJ9

